### PR TITLE
Update Super Bagman.mra

### DIFF
--- a/releases/Super Bagman.mra
+++ b/releases/Super Bagman.mra
@@ -17,7 +17,7 @@
 	<rom index="1">
 		<part>01</part>
 	</rom>
-	<rom index='0' md5='fa8e135d43bfafab71a3b608d825072b' type='merged|nonmerged|split' zip='sbagman.zip'>
+	<rom index='0' md5='fa8e135d43bfafab71a3b608d825072b' type='merged|nonmerged|split' zip='sbagman.zip|sbagman2.zip'>
 		<part crc='1b1d6b0a' name='5.9e'/>
 		<part crc='ac49cb82' name='6.9f'/>
 		<part crc='9a1c778d' name='7.9j'/>


### PR DESCRIPTION
Was missing reference to sbagman2.zip, needed if using split set later than 0.217. This seems to have changed in MAME set 0.218 (using 0.220 myself). 

Actually another thing I notice all filenames are changed also, adding sb or b at beginning of filename and version indicator (?) before dot: for example '13.8d' is called 'sb13v5.8d', '11.9r' is called 'b11v3.9r' etc. (Of course this doesnt matter anyway because CRC seems to be used to identify files rather than names.)