### PR TITLE
Restore correct Aspect Ratio and custom AR

### DIFF
--- a/Arcade-Bagman.sv
+++ b/Arcade-Bagman.sv
@@ -196,11 +196,11 @@ assign LED_POWER = 0;
 assign BUTTONS = 0;
 
 //////////////////////////////////////////////////////////////////
+	
+wire [1:0] ar = status[20:19];
 
-wire [1:0] ar = status[9:8];
-
-assign VIDEO_ARX = (!ar) ? 12'd4 : (ar - 1'd1);
-assign VIDEO_ARY = (!ar) ? 12'd3 : 12'd0;
+assign VIDEO_ARX = (!ar) ? ((status[2]|mod_squa)  ? 8'd4 : 8'd3) : (ar - 1'd1);
+assign VIDEO_ARY = (!ar) ? ((status[2]|mod_squa)  ? 8'd3 : 8'd4) : 12'd0;
 
 `include "build_id.v" 
 localparam CONF_STR = {


### PR DESCRIPTION
Last update to sys made aspect ratio incorrect and disabled the custom AR controls. This is now been restored.